### PR TITLE
Fix readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,8 +708,8 @@ numbers.Site.get(id, function(err,site){
 ```Javascript
 var subscription = {
   orderType:"orders",
-  callbackSubcription: {
-    url:"http://mycallbackurl.com",
+  callbackSubscription: {
+    URL:"http://mycallbackurl.com",
     user:"userid",
     expiry: 12000
   }


### PR DESCRIPTION
- fix typo (`callbackSubcription` => `callbackSubscription`) which resulted in:
    ```
    <SubscriptionResponse><ResponseStatus><ErrorCode>14501</ErrorCode><Description>Subscription object is invalid</Description></ResponseStatus></SubscriptionResponse>
    ```
- fix typo (`url` => `URL`) which resulted in:
    ```
    <SubscriptionResponse><ResponseStatus><ErrorCode>14503</ErrorCode><Description>Callback URL is empty</Description></ResponseStatus></SubscriptionResponse>
    ```