### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This SDK stable for node versions 7 and above
 | 1.1.0   | Added import tn functionality, added promise based `Async` functions                                                                      |
 | 1.2.0   | Added CSR lookup functionality                                                                                                            |
 | 1.2.1   | Fixed Subscription List functionality. Example code at: [examples/subscription_list_and_delete](examples/subscription_list_and_delete.js) |
+| 1.2.2   | Readme Typo for `RemoveImportedTnOrder`                                                                                                   |
 
 
 ## Install
@@ -856,7 +857,7 @@ const numbers = ["1111", "2222"];
 const customerOrderId = "customerOrderId"
 
 try {
-  const importTnOrder = await RemoveImportedTnOrder.createAsync(numbers, customerOrderId);
+  const importTnOrder = await RemoveImportedTnOrder.createAsync(customerOrderId, numbers);
   console.log(importTnOrder);
 }
 catch (e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandwidth/numbers",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "NodeJs Client library for Bandwidth Numbers API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
A typo with the README documentation of the Node JS SDK... in that Hosted Messages section, it says that to “Create removeImportedTnOrder” you should call “`const importTnOrder = await RemoveImportedTnOrder.createAsync(numbers, customerOrderId);`“... but arguments are switched... should be “`const importTnOrder = await RemoveImportedTnOrder.createAsync(customerOrderId, numbers);`”