### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,7 +688,7 @@ numbers.SipPeer.create(data, callback);
 ### Get SIP Peer
 
 ```Javascript
-numbers.SipPeer.get("id", callback);
+numbers.SipPeer.get(siteId, sipPeerId, callback);
 ```
 
 ### List SIP Peers


### PR DESCRIPTION
Argument params in the example didn't match the argument values in the method itself.