### PR TITLE
Sync bandwidth.com/languages annotation to Backstage catalog

### DIFF
--- a/.bandwidth/component.yaml
+++ b/.bandwidth/component.yaml
@@ -6,6 +6,7 @@ metadata:
   description: Node SDK for Bandwidth Numbers
   annotations:
     github.com/project-slug: Bandwidth/node-numbers
+    bandwidth.com/languages: Node.js
     organization: BW
     costCenter: Development - Software Infra
 spec:


### PR DESCRIPTION
Syncs the `bandwidth.com/languages` annotation in `.bandwidth/component.yaml` to match the repository's actual detected languages.

See: https://bandwidth-jira.atlassian.net/browse/SWI-11736

**Language change:** `(none)` → `Node.js`